### PR TITLE
Fix version on msf-ocp-release workflow

### DIFF
--- a/.github/workflows/build_publish_msf_release.yml
+++ b/.github/workflows/build_publish_msf_release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Download OMODs
         env:
           BUCKET_NAME: stable-artefacts
-          RELEASE_VERSION: 2.6.9
+          RELEASE_VERSION: msf-release-2.6.9
         run: |
           aws s3 cp s3://$BUCKET_NAME/$RELEASE_VERSION/openmrs-module-appointments/latest/ target/ --recursive
           aws s3 cp s3://$BUCKET_NAME/$RELEASE_VERSION/openmrs-module-bahmni.ie.apps/latest/ target/ --recursive


### PR DESCRIPTION
<!-- Add Jira card link -->

**Reason for Change:**
<!-- Provide a description on why this change is necessary if it is not mentioned in the JIRA. -->
- Release version was folder name doesn't match with the AWS, so the last build got failed.

**Description of Change:**
<!-- Provide a detailed explanation of the changes made in this PR. Include any relevant context or background information. -->
- Set Proper release version